### PR TITLE
Update to apollo compiler 0.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,13 +13,7 @@ A full usage example can be found in the [test project](https://github.com/Cox-A
     <dependency>
         <groupId>com.apollographql.apollo</groupId>
         <artifactId>apollo-runtime</artifactId>
-        <version>0.3.0</version>
-    </dependency>
-    <!-- Guava "Optional" used when generating queries with Apollo -->
-    <dependency>
-        <groupId>com.google.guava</groupId>
-        <artifactId>guava</artifactId>
-        <version>21.0</version>
+        <version>0.4.0</version>
     </dependency>
     ```
 2. Add the code generator plugin to your project's build (if codegen is desired):
@@ -27,7 +21,7 @@ A full usage example can be found in the [test project](https://github.com/Cox-A
     <plugin>
         <groupId>com.coxautodev</groupId>
         <artifactId>java-graphql-client-maven-plugin</artifactId>
-        <version>1.0.0</version>
+        <version>1.1.0</version>
         <executions>
             <execution>
                 <goals>
@@ -83,4 +77,4 @@ if(data.isPresent()) {
 }
 ```
 
-Properties specified as nullable in the schema will have an `Optional` type.
+Properties specified as nullable in the schema will have an java 8 `java.util.optional` type.

--- a/apollo-client-maven-plugin-tests/pom.xml
+++ b/apollo-client-maven-plugin-tests/pom.xml
@@ -9,7 +9,7 @@
     </parent>
 
     <artifactId>apollo-client-maven-plugin-tests</artifactId>
-    <version>1.0.1-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <properties>
@@ -21,12 +21,7 @@
         <dependency>
             <groupId>com.apollographql.apollo</groupId>
             <artifactId>apollo-runtime</artifactId>
-            <version>0.3.0</version>
-        </dependency>
-        <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-            <version>21.0</version>
+            <version>0.4.0</version>
         </dependency>
 
         <dependency>
@@ -66,7 +61,7 @@
             <plugin>
                 <groupId>com.coxautodev</groupId>
                 <artifactId>apollo-client-maven-plugin</artifactId>
-                <version>1.0.1-SNAPSHOT</version>
+                <version>1.1.0-SNAPSHOT</version>
                 <executions>
                     <execution>
                         <goals>

--- a/apollo-client-maven-plugin-tests/src/test/groovy/com/coxautodev/java/graphql/client/tests/IntegrationSpec.groovy
+++ b/apollo-client-maven-plugin-tests/src/test/groovy/com/coxautodev/java/graphql/client/tests/IntegrationSpec.groovy
@@ -2,8 +2,8 @@ package com.coxautodev.java.graphql.client.tests
 
 import com.apollographql.apollo.ApolloClient
 import com.coxautodev.graphql.tools.SchemaParser
-import com.coxautodev.java.graphql.client.tests.queries.GetBooks
-import com.coxautodev.java.graphql.client.tests.queries.author.GetAuthors
+import com.coxautodev.java.graphql.client.tests.queries.GetBooksQuery
+import com.coxautodev.java.graphql.client.tests.queries.author.GetAuthorsQuery
 import com.fasterxml.jackson.databind.ObjectMapper
 import graphql.execution.SimpleExecutionStrategy
 import graphql.servlet.GraphQLServlet
@@ -92,11 +92,11 @@ class IntegrationSpec extends Specification {
 
     def "generated book query returns data"() {
         expect:
-            client.newCall(new GetBooks()).execute().data().get().books().size() == 4
+            client.newCall(new GetBooksQuery()).execute().data().get().books().size() == 4
     }
 
     def "generated author query returns data"() {
         expect:
-            client.newCall(new GetAuthors()).execute().data().get().authors().size() == 2
+            client.newCall(new GetAuthorsQuery()).execute().data().get().authors().size() == 2
     }
 }

--- a/apollo-client-maven-plugin/pom.xml
+++ b/apollo-client-maven-plugin/pom.xml
@@ -9,7 +9,7 @@
     </parent>
 
     <artifactId>apollo-client-maven-plugin</artifactId>
-    <version>1.0.1-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
     <packaging>maven-plugin</packaging>
 
     <name>Maven plugin for generating graphql clients</name>
@@ -35,7 +35,7 @@
         <dependency>
             <groupId>com.apollographql.apollo</groupId>
             <artifactId>compiler</artifactId>
-            <version>0.3.0</version>
+            <version>0.4.0</version>
         </dependency>
 
         <dependency>

--- a/apollo-client-maven-plugin/src/main/kotlin/com/coxautodev/java/graphql/client/maven/plugin/GraphQLClientMojo.kt
+++ b/apollo-client-maven-plugin/src/main/kotlin/com/coxautodev/java/graphql/client/maven/plugin/GraphQLClientMojo.kt
@@ -1,7 +1,7 @@
 package com.coxautodev.java.graphql.client.maven.plugin
 
-import com.apollographql.android.compiler.GraphQLCompiler
-import com.apollographql.android.compiler.NullableValueType
+import com.apollographql.apollo.compiler.GraphQLCompiler
+import com.apollographql.apollo.compiler.NullableValueType
 import org.apache.maven.plugin.AbstractMojo
 import org.apache.maven.plugin.MojoExecutionException
 import org.apache.maven.plugins.annotations.LifecyclePhase
@@ -120,7 +120,7 @@ class GraphQLClientMojo: AbstractMojo() {
         }
 
         val compiler = GraphQLCompiler()
-        compiler.write(GraphQLCompiler.Arguments(schema, outputDirectory, mapOf(), NullableValueType.GUAVA_OPTIONAL, true))
+        compiler.write(GraphQLCompiler.Arguments(schema, outputDirectory, mapOf(), NullableValueType.JAVA_OPTIONAL, true, true))
 
         if(addSourceRoot ?: return) {
             project.addCompileSourceRoot(outputDirectory.absolutePath)

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>com.coxautodev</groupId>
     <artifactId>apollo-client-maven-plugin-parent</artifactId>
-    <version>1.0.1-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <properties>


### PR DESCRIPTION
- Bump plugin version to 1.1.0-SNAPSHOT
- Use java 8 optional instead of Guava optional
- Use "semantic naming" when generating classes (will add "Query" at the end of a query class, etc)