### PR TITLE
feat: add generated-sources to import path

### DIFF
--- a/apollo-client-maven-plugin/pom.xml
+++ b/apollo-client-maven-plugin/pom.xml
@@ -70,6 +70,18 @@
                             <goal>exec</goal>
                         </goals>
                     </execution>
+                    <execution>
+                        <id>add-source</id>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>add-source</goal>
+                        </goals>
+                        <configuration>
+                            <sources>
+                                <source>${project.build.directory}/generated-sources</source>
+                            </sources>
+                        </configuration>
+                    </execution>
                 </executions>
                 <configuration>
                     <executable>npm</executable>


### PR DESCRIPTION
add generated-sources path to sources tag in order to make generated classes accessible for import