### PR TITLE
Add skip option

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ All plugin options and their defaults:
     <basePackage>com.example.graphql.client</basePackage>
     <schemaFile>${project.basedir}/src/main/graphql/schema.json</schemaFile>
     <addSourceRoot>true</addSourceRoot>
+    <skip>false</skip>
 </configuration>
 ```
 

--- a/apollo-client-maven-plugin-tests/pom.xml
+++ b/apollo-client-maven-plugin-tests/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.coxautodev</groupId>
         <artifactId>apollo-client-maven-plugin-parent</artifactId>
-        <version>1.1.3-SNAPSHOT</version>
+        <version>1.1.4-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
 
@@ -64,7 +64,7 @@
             <plugin>
                 <groupId>com.coxautodev</groupId>
                 <artifactId>apollo-client-maven-plugin</artifactId>
-                <version>1.1.3-SNAPSHOT</version>
+                <version>1.1.4-SNAPSHOT</version>
                 <executions>
                     <execution>
                         <goals>

--- a/apollo-client-maven-plugin-tests/pom.xml
+++ b/apollo-client-maven-plugin-tests/pom.xml
@@ -24,7 +24,7 @@
         <dependency>
             <groupId>com.apollographql.apollo</groupId>
             <artifactId>apollo-runtime</artifactId>
-            <version>0.4.0</version>
+            <version>0.4.1</version>
         </dependency>
 
         <dependency>

--- a/apollo-client-maven-plugin/pom.xml
+++ b/apollo-client-maven-plugin/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.coxautodev</groupId>
         <artifactId>apollo-client-maven-plugin-parent</artifactId>
-        <version>1.1.3-SNAPSHOT</version>
+        <version>1.1.4-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/apollo-client-maven-plugin/pom.xml
+++ b/apollo-client-maven-plugin/pom.xml
@@ -36,7 +36,7 @@
         <dependency>
             <groupId>com.apollographql.apollo</groupId>
             <artifactId>compiler</artifactId>
-            <version>0.4.0</version>
+            <version>0.4.1</version>
         </dependency>
 
         <dependency>

--- a/apollo-client-maven-plugin/src/main/kotlin/com/coxautodev/java/graphql/client/maven/plugin/GraphQLClientMojo.kt
+++ b/apollo-client-maven-plugin/src/main/kotlin/com/coxautodev/java/graphql/client/maven/plugin/GraphQLClientMojo.kt
@@ -42,11 +42,19 @@ class GraphQLClientMojo: AbstractMojo() {
     @Parameter(property = "addSourceRoot", defaultValue = "true")
     private var addSourceRoot: Boolean? = null
 
+    @Parameter(property = "skip", defaultValue = "false")
+    private var skip: Boolean? = null
+
     @Parameter(readonly = true, required = true, defaultValue = "\${project}")
     private var project: MavenProject? = null
 
     @Throws(MojoExecutionException::class)
     override fun execute() {
+        if(skip == true) {
+            log.info("Skipping because skip is true")
+            return
+        }
+
         val project = this.project!!
         val outputDirectory = this.outputDirectory!!
         val basePackage = this.basePackage!!

--- a/apollo-client-maven-plugin/src/main/kotlin/com/coxautodev/java/graphql/client/maven/plugin/GraphQLClientMojo.kt
+++ b/apollo-client-maven-plugin/src/main/kotlin/com/coxautodev/java/graphql/client/maven/plugin/GraphQLClientMojo.kt
@@ -136,7 +136,7 @@ class GraphQLClientMojo: AbstractMojo() {
         }
 
         val compiler = GraphQLCompiler()
-        compiler.write(GraphQLCompiler.Arguments(schema, outputDirectory, mapOf(), NullableValueType.JAVA_OPTIONAL, true, true))
+        compiler.write(GraphQLCompiler.Arguments(schema, outputDirectory, mapOf(), NullableValueType.JAVA_OPTIONAL, true, true, true))
 
         if(addSourceRoot == true) {
             project.addCompileSourceRoot(outputDirectory.absolutePath)

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>com.coxautodev</groupId>
     <artifactId>apollo-client-maven-plugin-parent</artifactId>
-    <version>1.1.3-SNAPSHOT</version>
+    <version>1.1.4-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>apollo-client-maven-plugin-parent</name>


### PR DESCRIPTION
For some use-cases you don't want to run the plugin every time, so you just change the `<skip>` option to `true` and it shouldn't run.